### PR TITLE
fix(package.json): correct main export

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ets_proj_parser",
   "version": "1.0.2",
-  "main": "index.js",
+  "main": "dist/etsProjParser.js",
   "license": "MIT",
   "enigines": {
     "node": ">=8"


### PR DESCRIPTION
I believe we need to refer to the main file in the distribution built as `require('ets_proj_parser')` refers to that one.

It can be either used as `import etsProjParser from 'ets_proj_parser';` or `const etsProjParser = require('ets_proj_parser').default` after installing the `ets_proj_parser` dependency.